### PR TITLE
Fix display in top and bottom navbar

### DIFF
--- a/reports/javadoc/stylesheet.css
+++ b/reports/javadoc/stylesheet.css
@@ -119,7 +119,6 @@ Navigation bar styles
     width:100%;
     clear:right;
     height:2.8em;
-    padding-top:10px;
     overflow:hidden;
     font-size:12px; 
 }
@@ -133,7 +132,6 @@ Navigation bar styles
     width:100%;
     clear:right;
     height:2.8em;
-    padding-top:10px;
     overflow:hidden;
     font-size:12px;
 }


### PR DESCRIPTION
### Changes description
Fix display, currently both bottom and top navigation bar are shown as it follows:

![captura de pantalla 2018-05-28 a la s 10 37 13 a m](https://user-images.githubusercontent.com/30867977/40619541-747fed28-6263-11e8-8f89-13c563f5ebe1.png)

<!-- Describe results, user mentions, screenshots, screencast (gif) -->

How it'll look:
![captura de pantalla 2018-05-28 a la s 10 39 06 a m](https://user-images.githubusercontent.com/30867977/40619526-66d06720-6263-11e8-8801-e4351c2839a0.png)
### Checklist

Please check if your PR fulfills the following specifications:

- [ ] Tests for the changes have been added
- [x] Docs have been added/updated

### References

<!-- issues related (for reference or to be closed) and/or links of discuss -->

Closes #N/A